### PR TITLE
Add missing web and transformer dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ exceptiongroup==1.2.2
 feedparser==6.0.11
 filelock==3.16.1
 flatbuffers==24.3.25
+Flask==3.0.3
+Flask-SQLAlchemy==3.1.1
 fonttools==4.55.0
 frozenlist==1.5.0
 fsspec==2024.9.0
@@ -99,6 +101,7 @@ scikit-learn==1.5.2
 scipy==1.13.1
 seaborn==0.13.2
 semanticscholar==0.8.4
+sentence-transformers==2.2.2
 sgmllib3k==1.0.0
 shellingham==1.5.4
 six==1.16.0


### PR DESCRIPTION
## Summary
- Include Flask and Flask-SQLAlchemy for the web interface
- Add sentence-transformers for semantic search features

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2ee8506a083279ef3b1eabf1ea3c0