### PR TITLE
Use chat template for local LLaMA generation

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -46,7 +46,12 @@ def load_local_llama_model(model_path=None):
 def local_llama_generate(messages, temperature=None, max_new_tokens=512):
     model, tokenizer = load_local_llama_model()
     device = model.device
-    inputs = tokenizer.apply_chat_template(messages, return_tensors="pt").to(device)
+    inputs = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        return_tensors="pt"
+    ).to(device)
     gen_kwargs = {"max_new_tokens": max_new_tokens}
     if temperature is not None and temperature > 0:
         gen_kwargs.update({"do_sample": True, "temperature": temperature})


### PR DESCRIPTION
## Summary
- call `tokenizer.apply_chat_template` with tokenization and generation prompt to build inputs
- confirm the installed transformers version supports this API

## Testing
- `python -m py_compile inference.py`
- `python -c 'import transformers; print(transformers.__version__)'`


------
https://chatgpt.com/codex/tasks/task_e_68aee80b14f08327bbf2dc3262556430