### PR TITLE
Add Ollama backend for local LLaMA generation

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -6,6 +6,7 @@ import google.generativeai as genai
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 import logging
+import requests
 
 TOKENS_IN = dict()
 TOKENS_OUT = dict()
@@ -95,6 +96,38 @@ def local_llama_generate(messages, temperature=None, max_new_tokens=512):
         outputs = model.generate(inputs, **gen_kwargs)
     return tokenizer.decode(outputs[0, inputs.shape[-1]:], skip_special_tokens=True).strip()
 
+
+def ollama_llama_generate(messages, temperature=None, max_new_tokens=512, model_name=None):
+    """Generate a response using a locally running Ollama server.
+
+    Parameters
+    ----------
+    messages : list
+        Conversation messages in the same format used by query_model.
+    temperature : float, optional
+        Sampling temperature for generation. If ``None`` no temperature is set.
+    max_new_tokens : int, optional
+        Maximum number of tokens to generate. Defaults to 512.
+    model_name : str, optional
+        Name of the Ollama model to use. If ``None`` the ``OLLAMA_MODEL``
+        environment variable or ``"llama3.1:8b-instruct"`` is used.
+    """
+
+    model_name = model_name or os.getenv("OLLAMA_MODEL", "llama3.1:8b-instruct")
+    url = os.getenv("OLLAMA_API_BASE", "http://localhost:11434/api/chat")
+    payload = {
+        "model": model_name,
+        "messages": messages,
+        "stream": False,
+        "options": {"num_predict": max_new_tokens},
+    }
+    if temperature is not None and temperature > 0:
+        payload["options"]["temperature"] = temperature
+    response = requests.post(url, json=payload)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("message", {}).get("content", "").strip()
+
 def curr_cost_est():
     costmap_in = {
         "llama-3.1-8b": 0.20 / 1000000,
@@ -144,7 +177,7 @@ def query_model(model_str, prompt, system_prompt, openai_api_key=None, gemini_ap
                 llama_api_key = openai_api_key or groq_api
                 use_ollama = os.getenv("USE_OLLAMA", "").lower() in ["1", "true", "yes"]
                 if use_ollama:
-                    answer = local_llama_generate(messages, temperature=temp)
+                    answer = ollama_llama_generate(messages, temperature=temp)
                 elif llama_api_key:
                     client = OpenAI(api_key=llama_api_key, base_url=os.getenv("GROQ_API_BASE", "https://api.groq.com/openai/v1"))
                     if temp is None:


### PR DESCRIPTION
## Summary
- use requests-based helper to query local Ollama server
- route LLaMA calls to Ollama when `USE_OLLAMA` is enabled
- import requests for new HTTP helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee75ccb648327b3f784363e521828